### PR TITLE
Update TOC for QCSE

### DIFF
--- a/toc
+++ b/toc
@@ -27,7 +27,7 @@ Quantum Services
     {: .topicgroup}
     Developer community
         [Qiskit Slack](http://ibm.co/joinqiskitslack)
-        [IBM Quantum Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/ibm-q-experience)
+        [IBM Quantum Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/ibm-quantum-services)
         [Qiskit Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/qiskit)
 
 {: .topicgroup}


### PR DESCRIPTION
_IBM Q_ is being rebranded as _IBM Quantum_. quantumcomputing.stackexchange.com has an alias for the tag `ibm-q-experience` called `ibm-quantum-services` which I think is better to encourage its usage over the deprecated IBM Q one.