### PR TITLE
Fix formatting in session example

### DIFF
--- a/sessions.md
+++ b/sessions.md
@@ -30,8 +30,8 @@ Start by loading the options into a primitive constructor, then pass in circuits
 
 ```Python
 with Session(service) as session:
-    estimator = Estimator(session=session, options=options) #primitive constructor
-	 estimator.run(circuit, parameters, observable) #job call
+    estimator = Estimator(session=session, options=options)  #primitive constructor
+    estimator.run(circuit, parameters, observable)  #job call
 ```
 {: codeblock}
 


### PR DESCRIPTION
For python the indent matters, so the lines within the context manager should align. Also, maybe a nit, but most linters like flake8 will complain about not having two whitespaces before a comment.